### PR TITLE
feat: notifications changed event & indicator design

### DIFF
--- a/resources/views/components/notifications-indicator.blade.php
+++ b/resources/views/components/notifications-indicator.blade.php
@@ -1,7 +1,7 @@
 <div>
     @if($this->notificationsUnread ?? false)
-        <div class="absolute right-0 flex items-center justify-center w-3 h-3 mr-3 -mt-3 bg-white border-white rounded-full">
-            <div class="w-2 h-2 rounded-full bg-theme-danger-500"></div>
-        </div>
+        <span class="absolute right-0 block p-1 mr-2 -mt-4 bg-white rounded-full">
+            <span class="block w-1 h-1 rounded-full border-3 bg-theme-danger-500 border-theme-danger-500"></span>
+        </span>
     @endif
 </div>

--- a/resources/views/navbar-notifications.blade.php
+++ b/resources/views/navbar-notifications.blade.php
@@ -13,24 +13,24 @@
                                 {{ $notification->name() }}
                             </span>
 
-                            <span class="hidden text-sm text-theme-secondary-400 sm:block sm:text-right sm:w-full">
+                            <span class="hidden text-sm text-theme-secondary-400 md:block md:text-right md:w-full">
                                 {{ $notification->created_at_local->diffForHumans() }}
                             </span>
                         </div>
 
-                        <div class="flex flex-col justify-between md:space-x-3 sm:flex-row">
+                        <div class="flex flex-col justify-between md:space-x-3 md:flex-row">
                             <span class="notification-truncate">
                                 {{ $notification->data['content'] }}
                             </span>
 
                             <div class="flex flex-row space-x-4">
                                 @isset($notification->data['action'])
-                                    <span class="mt-1 font-semibold whitespace-nowrap link sm:mt-0">
+                                    <span class="mt-1 font-semibold whitespace-nowrap link md:mt-0">
                                         <a href="{{ $notification->data['action']['url'] }}">{{ $notification->data['action']['title'] }}</a>
                                     </span>
                                 @endisset
 
-                                <span class="block mt-1 text-sm sm:hidden text-theme-secondary-400">
+                                <span class="block mt-1 text-sm md:hidden text-theme-secondary-400">
                                     {{ $notification->created_at_local->diffForHumans() }}
                                 </span>
                             </div>

--- a/src/Components/NotificationsIndicator.php
+++ b/src/Components/NotificationsIndicator.php
@@ -24,6 +24,8 @@ final class NotificationsIndicator extends Component
         Auth::user()->update(['seen_notifications_at' => Carbon::now()]);
 
         $this->notificationsUnread = false;
+
+        $this->emit('notificationsCountUpdated');
     }
 
     public function render(): View


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Now once the notifications count change it emits an event that eventually should be emitted also when the messages are read or the invitations change so we can toggle a single indicator on the mobile menu that groups all the notifications.

![image](https://user-images.githubusercontent.com/17262776/106057035-4a962d80-60e7-11eb-9911-edb238cb8fd5.png)

Also updates the design of the indicator to match the current design


## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
