### PR TITLE
refactor: mark all as read button, and chevron open state

### DIFF
--- a/resources/views/components/manage-notifications.blade.php
+++ b/resources/views/components/manage-notifications.blade.php
@@ -24,7 +24,7 @@
                                     {{ ucfirst($this->activeFilter) }}
                                 </span>
 
-                                <span :class="{ 'rotate-180': open }" class="transition duration-150 ease-in-out text-theme-primary-600">
+                                <span :class="{ 'rotate-180': dropdownOpen }" class="transition duration-150 ease-in-out text-theme-primary-600">
                                     <x-ark-icon name="chevron-down" size="xs" />
                                 </span>
                             </div>
@@ -65,10 +65,10 @@
                     </x-ark-dropdown>
                 </div>
             </div>
-            <span class="items-center justify-end hidden cursor-pointer sm:flex link">@lang('hermes::actions.mark_all_as_read')</span>
+            <button type="button" class="items-center justify-end hidden cursor-pointer sm:flex link" wire:click="markAllAsRead">@lang('hermes::actions.mark_all_as_read')</button>
         </div>
 
-        <span class="flex items-center mt-2 sm:hidden link">@lang('hermes::actions.mark_all_as_read')</span>
+        <button type="button" class="flex items-center mt-2 sm:hidden link" wire:click="markAllAsRead">@lang('hermes::actions.mark_all_as_read')</button>
 
         @if ($notificationCount > 0 && $this->notifications->count() > 0)
             @foreach($this->notifications as $notification)

--- a/src/Components/ManageNotifications.php
+++ b/src/Components/ManageNotifications.php
@@ -100,6 +100,11 @@ final class ManageNotifications extends Component
         }
     }
 
+    public function markAllAsRead(): void
+    {
+        $this->user->notifications->each->markAsRead();
+    }
+
     public function markAsUnread(string $notificationId): void
     {
         $this->user->notifications()->findOrFail($notificationId)->markAsUnread();


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

- Implements the functionality for the markAllAsRead button
- Now the chevron rotates when the dropdown is open

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
