### PR TITLE
feat: handle custom logo types on the notifications views

### DIFF
--- a/resources/views/components/manage-notifications.blade.php
+++ b/resources/views/components/manage-notifications.blade.php
@@ -102,6 +102,8 @@
                                 <div class="flex">
                                     <x-hermes-notification-icon
                                         :logo="$notification->logo()"
+                                        :logo-media="$notification->logoMedia()"
+                                        :logo-identifier="$notification->logoIdentifier()"
                                         :type="$notification->data['type']"
                                         :state-color="$this->getStateColor($notification)"
                                     />

--- a/resources/views/navbar-notifications.blade.php
+++ b/resources/views/navbar-notifications.blade.php
@@ -5,6 +5,8 @@
                 <div class="flex px-2 py-6 leading-5 {{ ! $loop->last ? 'border-b border-dashed border-theme-secondary-200' : '' }}">
                     <x-hermes-notification-icon
                         :logo="$notification->logo()"
+                        :logo-media="$notification->logoMedia()"
+                        :logo-identifier="$notification->logoIdentifier()"
                         :type="$notification->data['type']"
                     />
                     <div class="flex flex-col w-full ml-5 space-y-1">

--- a/resources/views/notification-icon.blade.php
+++ b/resources/views/notification-icon.blade.php
@@ -1,6 +1,10 @@
 <div class="relative inline-block pointer-events-none avatar-wrapper">
     <div class="relative w-11 h-11">
-        @isset($logo)
+        @if(isset($logoMedia))
+            {{ $logoMedia->img('', ['class' => 'absolute object-cover w-full h-full rounded-md']) }}
+        @elseif(isset($logoIdentifier))
+            <x-ark-avatar :identifier="$logoIdentifier" class="absolute object-cover w-full h-full rounded-md" />
+        @elseif(isset($logo))
             <img class="object-cover rounded-md" src="{{ $logo }}" />
         @else
             <div class="border border-theme-secondary-200 w-11 h-11"></div>

--- a/src/Models/DatabaseNotification.php
+++ b/src/Models/DatabaseNotification.php
@@ -5,6 +5,7 @@ namespace ARKEcosystem\Hermes\Models;
 use ARKEcosystem\Fortify\Models\Concerns\HasLocalizedTimestamps;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Notifications\DatabaseNotification as BaseNotification;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
 abstract class DatabaseNotification extends BaseNotification
 {
@@ -14,4 +15,8 @@ abstract class DatabaseNotification extends BaseNotification
     abstract public function name(): string;
 
     abstract public function logo(): string;
+
+    abstract public function logoMedia(): ?Media;
+
+    abstract public function logoIdentifier(): ?string;
 }

--- a/src/Models/DatabaseNotification.php
+++ b/src/Models/DatabaseNotification.php
@@ -16,7 +16,13 @@ abstract class DatabaseNotification extends BaseNotification
 
     abstract public function logo(): string;
 
-    abstract public function logoMedia(): ?Media;
+    public function logoMedia(): ?Media
+    {
+        return null;
+    }
 
-    abstract public function logoIdentifier(): ?string;
+    public function logoIdentifier(): ?string
+    {
+        return null;
+    }
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

This PR updates the notifications views and the DatabaseNotification to handle new parameters on the notification objects that can be used to add custom `Media` responsive images, custom images with identifiers or finally change the image used as the logo.

With this PR the `toDatabase` will accept `logo`, `logoMediaId`, `logoIdentiifier`

```php
public function toDatabase(User $notifiable): array {
        return [
            //....
            'logoMediaId' => optional($this->projectViewModel->logo())->id,
            'logoIdentifier' => $this->projectViewModel->fallbackIdentifier(),
        ];
    }
}
```

Related to this ticket https://app.clickup.com/t/fv645z

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
