### PR TITLE
feat: make notifications relatable morphable models

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -7,10 +7,10 @@ This file contains basic examples and explains the parameters that can be used f
 ### Notification Icon
 
 ```php
-<x-hermes-notification-icon type="danger" :logo="$notification->token->logo" />
-<x-hermes-notification-icon type="success" :logo="$notification->token->logo" />
-<x-hermes-notification-icon type="warning" :logo="$notification->token->logo" />
-<x-hermes-notification-icon type="info" :logo="$notification->token->logo" />
-<x-hermes-notification-icon type="warning" :logo="$notification->token->logo" state-color="bg-green-100" />
+<x-hermes-notification-icon type="danger" :notification="$notification" />
+<x-hermes-notification-icon type="success" :notification="$notification" />
+<x-hermes-notification-icon type="warning" :notification="$notification" />
+<x-hermes-notification-icon type="info" :notification="$notification" />
+<x-hermes-notification-icon type="warning" :notification="$notification" state-color="bg-green-100" />
 <x-hermes-notification-icon type="warning" />
 ```

--- a/database/migrations/2020_11_17_000000_create_notifications_table.php
+++ b/database/migrations/2020_11_17_000000_create_notifications_table.php
@@ -14,6 +14,7 @@ final class CreateNotificationsTable extends Migration
             $table->uuid('id')->primary();
             $table->string('type');
             $table->morphs('notifiable');
+            $table->morphs('relatable');
             $table->text('data');
             $table->timestamp('read_at')->nullable();
             $table->boolean('is_starred')->default(false);

--- a/resources/views/components/manage-notifications.blade.php
+++ b/resources/views/components/manage-notifications.blade.php
@@ -101,9 +101,7 @@
                             <div class="flex flex-row w-full space-x-4">
                                 <div class="flex">
                                     <x-hermes-notification-icon
-                                        :logo="$notification->logo()"
-                                        :logo-media="$notification->logoMedia()"
-                                        :logo-identifier="$notification->logoIdentifier()"
+                                        :notification="$notification"
                                         :type="$notification->data['type']"
                                         :state-color="$this->getStateColor($notification)"
                                     />

--- a/resources/views/navbar-notifications.blade.php
+++ b/resources/views/navbar-notifications.blade.php
@@ -4,11 +4,10 @@
             @foreach($currentUser->notifications->take(4) as $notification)
                 <div class="flex px-2 py-6 leading-5 {{ ! $loop->last ? 'border-b border-dashed border-theme-secondary-200' : '' }}">
                     <x-hermes-notification-icon
-                        :logo="$notification->logo()"
-                        :logo-media="$notification->logoMedia()"
-                        :logo-identifier="$notification->logoIdentifier()"
+                        :notification="$notification"
                         :type="$notification->data['type']"
                     />
+
                     <div class="flex flex-col w-full ml-5 space-y-1">
                         <div class="flex flex-row justify-between">
                             <span class="font-semibold text-theme-secondary-900 @if(strlen($notification->name()) > 32)notification-truncate @endif">

--- a/resources/views/notification-icon.blade.php
+++ b/resources/views/notification-icon.blade.php
@@ -1,11 +1,24 @@
+@props([
+    'notification',
+    'type' => '',
+    'stateColor' => 'bg-white',
+])
+
+@php
+    $relatable = $notification->relatable;
+    $media = optional($relatable)->logo(); 
+    $identifier = optional($relatable)->fallbackIdentifier(); 
+    $defaultLogo =  $notification->logo();
+@endphp
+
 <div class="relative inline-block pointer-events-none avatar-wrapper">
     <div class="relative w-11 h-11">
-        @if(isset($logoMedia))
-            {{ $logoMedia->img('', ['class' => 'absolute object-cover w-full h-full rounded-md']) }}
-        @elseif(isset($logoIdentifier))
-            <x-ark-avatar :identifier="$logoIdentifier" class="absolute object-cover w-full h-full rounded-md" />
-        @elseif(isset($logo))
-            <img class="object-cover rounded-md" src="{{ $logo }}" />
+        @if($media)
+            {{ $media->img('', ['class' => 'absolute object-cover w-full h-full rounded-md']) }}
+        @elseif($identifier)
+            <x-ark-avatar :identifier="$identifier" class="absolute object-cover w-full h-full rounded-md" />
+        @elseif($defaultLogo)
+            <img class="object-cover rounded-md" src="{{ $defaultLogo }}" />
         @else
             <div class="border border-theme-secondary-200 w-11 h-11"></div>
         @endif
@@ -14,7 +27,7 @@
             class="absolute flex items-center justify-center text-transparent rounded-full avatar-circle shadow-solid"
             style="right: -0.8rem; top: -0.9rem;"
         >
-            <div class="flex flex-shrink-0 items-center justify-center rounded-full {{ $stateColor ?? 'bg-white' }} h-7 w-7">
+            <div class="flex flex-shrink-0 items-center justify-center rounded-full {{ $stateColor }} h-7 w-7">
                 @if ($type === 'danger')
                     <div class="flex items-center justify-center flex-shrink-0 w-6 h-6 rounded-full bg-theme-danger-100">
                         @svg('alert-danger', 'text-theme-danger-400 h-4 w-4')

--- a/src/Contracts/HasNotificationLogo.php
+++ b/src/Contracts/HasNotificationLogo.php
@@ -7,6 +7,6 @@ use Spatie\MediaLibrary\MediaCollections\Models\Media;
 interface HasNotificationLogo
 {
     public function logo(): ?Media;
-    
+
     public function fallbackIdentifier(): ?string;
 }

--- a/src/Contracts/HasNotificationLogo.php
+++ b/src/Contracts/HasNotificationLogo.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace ARKEcosystem\Hermes\Contracts;
+
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+
+interface HasNotificationLogo
+{
+    public function logo(): ?Media;
+    
+    public function fallbackIdentifier(): ?string;
+}

--- a/src/Models/DatabaseNotification.php
+++ b/src/Models/DatabaseNotification.php
@@ -27,7 +27,7 @@ abstract class DatabaseNotification extends BaseNotification
     {
         // When creating a new DatabaseNotification, we are only allowed to fill
         // the `data` attribute so there is no easy way to assign the relatable
-        // model. As a workaorund to avoid the need to add more steps that may 
+        // model. As a workaorund to avoid the need to add more steps that may
         // complicate the notification creation the lines here take the relatable
         // info from the data and move it to the proper columns before storing the
         // model in the database.

--- a/src/Models/DatabaseNotification.php
+++ b/src/Models/DatabaseNotification.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Arr;
 /**
  * @property string $relatable_type
  * @property int $relatable_id
+ * @property array $data
  */
 abstract class DatabaseNotification extends BaseNotification
 {

--- a/src/Models/DatabaseNotification.php
+++ b/src/Models/DatabaseNotification.php
@@ -4,25 +4,38 @@ namespace ARKEcosystem\Hermes\Models;
 
 use ARKEcosystem\Fortify\Models\Concerns\HasLocalizedTimestamps;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Notifications\DatabaseNotification as BaseNotification;
-use Spatie\MediaLibrary\MediaCollections\Models\Media;
+use Illuminate\Support\Arr;
 
 abstract class DatabaseNotification extends BaseNotification
 {
     use HasFactory;
     use HasLocalizedTimestamps;
 
+    /**
+     * Register any events for your application.
+     *
+     * @return void
+     */
+    protected static function booted()
+    {
+        static::creating(function (DatabaseNotification $notification) {
+            $data = Arr::get($notification, 'data');
+            $notification->relatable_id = Arr::get($data, 'relatable_id');
+            $notification->relatable_type = Arr::get($data, 'relatable_type');
+            unset($data['relatable_type']);
+            unset($data['relatable_id']);
+            $notification->data = $data;
+        });
+    }
+
+    public function relatable(): MorphTo
+    {
+        return $this->morphTo('relatable', 'relatable_type', 'relatable_id');
+    }
+
     abstract public function name(): string;
 
     abstract public function logo(): string;
-
-    public function logoMedia(): ?Media
-    {
-        return null;
-    }
-
-    public function logoIdentifier(): ?string
-    {
-        return null;
-    }
 }

--- a/src/Models/DatabaseNotification.php
+++ b/src/Models/DatabaseNotification.php
@@ -20,12 +20,12 @@ abstract class DatabaseNotification extends BaseNotification
      */
     protected static function booted()
     {
-        static::creating(function (DatabaseNotification $notification) {
+        static::creating(function (self $notification) {
             $data = Arr::get($notification, 'data');
             $notification->relatable_id = Arr::get($data, 'relatable_id');
             $notification->relatable_type = Arr::get($data, 'relatable_type');
-            unset($data['relatable_type']);
-            unset($data['relatable_id']);
+            unset($data['relatable_type'], $data['relatable_id']);
+
             $notification->data = $data;
         });
     }

--- a/src/Models/DatabaseNotification.php
+++ b/src/Models/DatabaseNotification.php
@@ -25,6 +25,12 @@ abstract class DatabaseNotification extends BaseNotification
      */
     protected static function booted()
     {
+        // When creating a new DatabaseNotification, we are only allowed to fill
+        // the `data` attribute so there is no easy way to assign the relatable
+        // model. As a workaorund to avoid the need to add more steps that may 
+        // complicate the notification creation the lines here take the relatable
+        // info from the data and move it to the proper columns before storing the
+        // model in the database.
         static::creating(function (self $notification) {
             $data = Arr::get($notification, 'data');
             $notification->relatable_id = Arr::get($data, 'relatable_id');

--- a/src/Models/DatabaseNotification.php
+++ b/src/Models/DatabaseNotification.php
@@ -8,6 +8,10 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Notifications\DatabaseNotification as BaseNotification;
 use Illuminate\Support\Arr;
 
+/**
+ * @property string $relatable_type
+ * @property int $relatable_id
+ */
 abstract class DatabaseNotification extends BaseNotification
 {
     use HasFactory;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Add a `relatable` relationship to the notifications so we can grap the logo from the related model, you can see an example of use on the msq PR: https://github.com/ArkEcosystem/marketsquare.io/pull/1506/files

adds a new `HasNotificationLogo ` interface that the relatable models should implement to ensure they have the necessary methods to grab the logo from a media file oridentifier

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
