### PR TITLE
fix: truncate long titles and use full width for notifications dropdown

### DIFF
--- a/resources/views/navbar-notifications.blade.php
+++ b/resources/views/navbar-notifications.blade.php
@@ -8,13 +8,13 @@
                         :type="$notification->data['type']"
                     />
 
-                    <div class="flex flex-col w-full ml-5 space-y-1">
+                    <div class="flex flex-col w-full ml-5 space-y-1 overflow-auto">
                         <div class="flex flex-row justify-between">
-                            <span class="font-semibold text-theme-secondary-900 @if(strlen($notification->name()) > 32)notification-truncate @endif">
+                            <span class="flex-grow font-semibold truncate text-theme-secondary-900">
                                 {{ $notification->name() }}
                             </span>
 
-                            <span class="hidden text-sm text-theme-secondary-400 md:block md:text-right md:w-full">
+                            <span class="hidden text-sm text-theme-secondary-400 md:block md:text-right whitespace-nowrap">
                                 {{ $notification->created_at_local->diffForHumans() }}
                             </span>
                         </div>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Prevent multiline titles in the notifications and ensures it truncates the long titles:

The mobile version depends on: https://github.com/ArkEcosystem/laravel-ui/pull/369/files (otherwise the dropdown grows over the width of the screen)

Before:
![image](https://user-images.githubusercontent.com/17262776/112023157-e31abe00-8b2a-11eb-98f2-f78ad6867104.png)


After: 
![image](https://user-images.githubusercontent.com/17262776/112023207-f0d04380-8b2a-11eb-99b0-a8a041135a1c.png)

Test by sending an announcement on the /nova admin panel with a long title (#protip you can also modify the text of the notification with the devtools)



## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
