### PR TITLE
chore: the relatable column should be nullable

### DIFF
--- a/database/migrations/2020_11_17_000000_create_notifications_table.php
+++ b/database/migrations/2020_11_17_000000_create_notifications_table.php
@@ -14,7 +14,7 @@ final class CreateNotificationsTable extends Migration
             $table->uuid('id')->primary();
             $table->string('type');
             $table->morphs('notifiable');
-            $table->morphs('relatable');
+            $table->nullableMorphs('relatable');
             $table->text('data');
             $table->timestamp('read_at')->nullable();
             $table->boolean('is_starred')->default(false);


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Notice that the relatable column is not nullable so it can cause an exception if we create a notification without any model (default logo) 

Example this one https://github.com/ArkEcosystem/marketsquare.io/pull/1543


## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
