### PR TITLE
feat: cascade delete notifications

### DIFF
--- a/database/migrations/2020_11_17_000000_create_notifications_table.php
+++ b/database/migrations/2020_11_17_000000_create_notifications_table.php
@@ -15,6 +15,7 @@ final class CreateNotificationsTable extends Migration
             $table->string('type');
             $table->morphs('notifiable');
             $table->morphs('relatable');
+            $table->nullableMorphs('relatable_logo');
             $table->text('data');
             $table->timestamp('read_at')->nullable();
             $table->boolean('is_starred')->default(false);

--- a/src/Models/Concerns/HasRelatedNotifications.php
+++ b/src/Models/Concerns/HasRelatedNotifications.php
@@ -4,26 +4,26 @@ namespace ARKEcosystem\Hermes\Models\Concerns;
 
 trait HasRelatedNotifications
 {
-  public function relatedNotifications()
-  {
-      return $this->morphMany(config('hermes.models.notification'), 'relatable');
-  }
+    public function relatedNotifications()
+    {
+        return $this->morphMany(config('hermes.models.notification'), 'relatable');
+    }
 
-  public function relatedNotificationsByLogo()
-  {
-      return $this->morphMany(config('hermes.models.notification'), 'relatable_logo');
-  }
+    public function relatedNotificationsByLogo()
+    {
+        return $this->morphMany(config('hermes.models.notification'), 'relatable_logo');
+    }
 
-  /**
-   * Register any events for your application.
-   *
-   * @return void
-   */
-  protected static function bootHasRelatedNotifications()
-  {
-      static::deleting(function (self $model) {
-        $model->relatedNotifications()->delete();
-        $model->relatedNotificationsByLogo()->delete();
-      });
-  }
+    /**
+     * Register any events for your application.
+     *
+     * @return void
+     */
+    protected static function bootHasRelatedNotifications()
+    {
+        static::deleting(function (self $model) {
+            $model->relatedNotifications()->delete();
+            $model->relatedNotificationsByLogo()->delete();
+        });
+    }
 }

--- a/src/Models/Concerns/HasRelatedNotifications.php
+++ b/src/Models/Concerns/HasRelatedNotifications.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace ARKEcosystem\Hermes\Models\Concerns;
+
+trait HasRelatedNotifications
+{
+  public function relatedNotifications()
+  {
+      return $this->morphMany(config('hermes.models.notification'), 'relatable');
+  }
+
+  /**
+   * Register any events for your application.
+   *
+   * @return void
+   */
+  protected static function bootHasRelatedNotifications()
+  {
+      static::deleting(function (self $model) {
+        $model->relatedNotifications()->delete();
+      });
+  }
+}

--- a/src/Models/Concerns/HasRelatedNotifications.php
+++ b/src/Models/Concerns/HasRelatedNotifications.php
@@ -9,6 +9,11 @@ trait HasRelatedNotifications
       return $this->morphMany(config('hermes.models.notification'), 'relatable');
   }
 
+  public function relatedNotificationsByLogo()
+  {
+      return $this->morphMany(config('hermes.models.notification'), 'relatable_logo');
+  }
+
   /**
    * Register any events for your application.
    *
@@ -18,6 +23,7 @@ trait HasRelatedNotifications
   {
       static::deleting(function (self $model) {
         $model->relatedNotifications()->delete();
+        $model->relatedNotificationsByLogo()->delete();
       });
   }
 }

--- a/src/Models/DatabaseNotification.php
+++ b/src/Models/DatabaseNotification.php
@@ -11,6 +11,8 @@ use Illuminate\Support\Arr;
 /**
  * @property string $relatable_type
  * @property int $relatable_id
+ * @property string $relatable_logo_type
+ * @property int $relatable_logo_id
  * @property array $data
  */
 abstract class DatabaseNotification extends BaseNotification
@@ -35,7 +37,9 @@ abstract class DatabaseNotification extends BaseNotification
             $data = Arr::get($notification, 'data');
             $notification->relatable_id = Arr::get($data, 'relatable_id');
             $notification->relatable_type = Arr::get($data, 'relatable_type');
-            unset($data['relatable_type'], $data['relatable_id']);
+            $notification->relatable_logo_id = Arr::get($data, 'relatable_logo_id');
+            $notification->relatable_logo_type = Arr::get($data, 'relatable_logo_type');
+            unset($data['relatable_type'], $data['relatable_id'], $data['relatable_logo_type'], $data['relatable_logo_id']);
 
             $notification->data = $data;
         });
@@ -44,6 +48,15 @@ abstract class DatabaseNotification extends BaseNotification
     public function relatable(): MorphTo
     {
         return $this->morphTo('relatable', 'relatable_type', 'relatable_id');
+    }
+
+    public function relatableLogo(): MorphTo
+    {
+        if ($this->relatable_logo_type && $this->relatable_logo_id) {
+            return $this->morphTo('relatable', 'relatable_logo_type', 'relatable_logo_id');
+        }
+
+        return $this->relatable();
     }
 
     abstract public function name(): string;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Related to https://app.clickup.com/t/gb04vt

1. Adds a new morphable relationship (relatable_logo), this is a new _optional_ relationship used to define a different model for getting the notification logo while the notification is still related to another model. To better exemplify consider the use case of the notifications for mentions on the reviews, that notification is related to a review (so if the review is deleted the notification need to be deleted too but the image that we use in the notification is the user that mention you avatar), in this example we need to have the relationship to both models.

2. Adds the `HasRelatedNotifications`  trait that when used on a model will remove all the notifications related to that model when the model is deleted.


## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
