### PR TITLE
feat: add reset filters button when no results

### DIFF
--- a/resources/lang/en/actions.php
+++ b/resources/lang/en/actions.php
@@ -6,4 +6,5 @@ return [
     'mark_all_as_read'   => 'Mark all as read',
     'show_all'           => 'Show all',
     'open_notifications' => 'Open notifications',
+    'reset_filters'      => 'Reset filters',
 ];

--- a/resources/views/components/manage-notifications.blade.php
+++ b/resources/views/components/manage-notifications.blade.php
@@ -1,5 +1,5 @@
 <div>
-    <h1 class="text-2xl font-bold md:text-4xl px-6">@lang('hermes::pages.notifications.page_title')</h1>
+    <h1 class="px-6 text-2xl font-bold md:text-4xl">@lang('hermes::pages.notifications.page_title')</h1>
 
     <div class="flex flex-col">
         <div class="flex flex-row justify-between w-full mt-4 mb-2 text-base font-semibold sm:px-6">
@@ -17,7 +17,7 @@
                 </div>
 
                 <div class="relative">
-                    <x-ark-dropdown wrapper-class="inline-block" dropdown-classes="mt-3" button-class="h-10 dropdown-button-outline flex justify-center items-center p-4">
+                    <x-ark-dropdown wrapper-class="inline-block" dropdown-classes="mt-3" button-class="flex items-center justify-center h-10 p-4 dropdown-button-outline">
                         @slot('button')
                             <div class="inline-flex items-center justify-center w-full space-x-2">
                                 <span class="w-full font-semibold text-left text-theme-secondary-900">
@@ -159,7 +159,7 @@
                 </div>
             @endif
         @else
-            <div class="p-4 mt-5 border-2 rounded cursor-pointer border-theme-secondary-200">
+            <div class="flex flex-col items-center justify-between p-4 mt-5 space-y-2 border-2 rounded cursor-pointer border-theme-secondary-200 sm:flex-row sm:space-y-0">
                 <span>
                     @if (ARKEcosystem\Hermes\Enums\NotificationFilterEnum::isAll($this->activeFilter))
                         @lang('hermes::menus.notifications.no_notifications')
@@ -167,6 +167,12 @@
                         @lang('hermes::menus.notifications.no_filtered_notifications', ['filter' => $this->activeFilter])
                     @endif
                 </span>
+
+                <button wire:click="applyFilter('')" type="button" class="flex items-center space-x-2 button-secondary">
+                    <x-ark-icon name="reset" />
+
+                    <span>@lang('hermes::actions.reset_filters')</span>
+                </button>
             </div>
         @endif
     </div>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/qk5rw6

As the title says

To test open the notification page (`/user/notifications`) and filter the notification by starred you should see a "reset filters" button, (unless you have a starred notification of course)

![image](https://user-images.githubusercontent.com/17262776/114468398-05937a80-9bb1-11eb-9828-794ad9c84780.png)



## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
