### PR TITLE
feat: unselect notifications when action performed

### DIFF
--- a/resources/views/components/manage-notifications.blade.php
+++ b/resources/views/components/manage-notifications.blade.php
@@ -39,30 +39,34 @@
                     </x-ark-dropdown>
                 </div>
 
-                <div class="w-10 sm:relative">
-                    <x-ark-dropdown wrapper-class="top-0 right-0 inline-block text-left sm:absolute" dropdown-classes="left-0 w-64 mt-3" button-class="flex justify-center w-10 h-10 rounded bg-theme-primary-100 text-theme-primary-600">
-                        <div class="py-3">
-                            <div class="cursor-pointer dropdown-entry" wire:click="markSelectedAsRead">
-                                @lang('hermes::menus.notifications-dropdown.mark_selected_as_read')
-                            </div>
+                <div>
+                    @if (count($this->selectedNotifications))
+                        <div class="w-10 sm:relative">
+                            <x-ark-dropdown wrapper-class="top-0 right-0 inline-block text-left sm:absolute" dropdown-classes="left-0 w-64 mt-3" button-class="flex justify-center w-10 h-10 rounded bg-theme-primary-100 text-theme-primary-600">
+                                <div class="py-3">
+                                    <div class="cursor-pointer dropdown-entry" wire:click="markSelectedAsRead">
+                                        @lang('hermes::menus.notifications-dropdown.mark_selected_as_read')
+                                    </div>
 
-                            <div class="cursor-pointer dropdown-entry" wire:click="markSelectedAsUnread">
-                                @lang('hermes::menus.notifications-dropdown.mark_selected_as_unread')
-                            </div>
+                                    <div class="cursor-pointer dropdown-entry" wire:click="markSelectedAsUnread">
+                                        @lang('hermes::menus.notifications-dropdown.mark_selected_as_unread')
+                                    </div>
 
-                            <div class="cursor-pointer dropdown-entry" wire:click="markSelectedAsStarred">
-                                @lang('hermes::menus.notifications-dropdown.mark_selected_as_starred')
-                            </div>
+                                    <div class="cursor-pointer dropdown-entry" wire:click="markSelectedAsStarred">
+                                        @lang('hermes::menus.notifications-dropdown.mark_selected_as_starred')
+                                    </div>
 
-                            <div class="cursor-pointer dropdown-entry" wire:click="markSelectedAsUnstarred">
-                                @lang('hermes::menus.notifications-dropdown.unstar_selected')
-                            </div>
+                                    <div class="cursor-pointer dropdown-entry" wire:click="markSelectedAsUnstarred">
+                                        @lang('hermes::menus.notifications-dropdown.unstar_selected')
+                                    </div>
 
-                            <div class="cursor-pointer dropdown-entry" wire:click="deleteSelected">
-                                @lang('hermes::menus.notifications-dropdown.mark_selected_as_delete')
-                            </div>
+                                    <div class="cursor-pointer dropdown-entry" wire:click="deleteSelected">
+                                        @lang('hermes::menus.notifications-dropdown.mark_selected_as_delete')
+                                    </div>
+                                </div>
+                            </x-ark-dropdown>
                         </div>
-                    </x-ark-dropdown>
+                    @endif
                 </div>
             </div>
             <button type="button" class="items-center justify-end hidden cursor-pointer sm:flex link" wire:click="markAllAsRead">@lang('hermes::actions.mark_all_as_read')</button>

--- a/resources/views/components/manage-notifications.blade.php
+++ b/resources/views/components/manage-notifications.blade.php
@@ -39,34 +39,30 @@
                     </x-ark-dropdown>
                 </div>
 
-                <div>
-                    @if (count($this->selectedNotifications))
-                        <div class="w-10 sm:relative">
-                            <x-ark-dropdown wrapper-class="top-0 right-0 inline-block text-left sm:absolute" dropdown-classes="left-0 w-64 mt-3" button-class="flex justify-center w-10 h-10 rounded bg-theme-primary-100 text-theme-primary-600">
-                                <div class="py-3">
-                                    <div class="cursor-pointer dropdown-entry" wire:click="markSelectedAsRead">
-                                        @lang('hermes::menus.notifications-dropdown.mark_selected_as_read')
-                                    </div>
+                <div class="w-10 sm:relative">
+                    <x-ark-dropdown wrapper-class="top-0 right-0 inline-block text-left sm:absolute" dropdown-classes="left-0 w-64 mt-3" button-class="flex justify-center w-10 h-10 rounded bg-theme-primary-100 text-theme-primary-600">
+                        <div class="py-3">
+                            <div class="cursor-pointer dropdown-entry" wire:click="markSelectedAsRead">
+                                @lang('hermes::menus.notifications-dropdown.mark_selected_as_read')
+                            </div>
 
-                                    <div class="cursor-pointer dropdown-entry" wire:click="markSelectedAsUnread">
-                                        @lang('hermes::menus.notifications-dropdown.mark_selected_as_unread')
-                                    </div>
+                            <div class="cursor-pointer dropdown-entry" wire:click="markSelectedAsUnread">
+                                @lang('hermes::menus.notifications-dropdown.mark_selected_as_unread')
+                            </div>
 
-                                    <div class="cursor-pointer dropdown-entry" wire:click="markSelectedAsStarred">
-                                        @lang('hermes::menus.notifications-dropdown.mark_selected_as_starred')
-                                    </div>
+                            <div class="cursor-pointer dropdown-entry" wire:click="markSelectedAsStarred">
+                                @lang('hermes::menus.notifications-dropdown.mark_selected_as_starred')
+                            </div>
 
-                                    <div class="cursor-pointer dropdown-entry" wire:click="markSelectedAsUnstarred">
-                                        @lang('hermes::menus.notifications-dropdown.unstar_selected')
-                                    </div>
+                            <div class="cursor-pointer dropdown-entry" wire:click="markSelectedAsUnstarred">
+                                @lang('hermes::menus.notifications-dropdown.unstar_selected')
+                            </div>
 
-                                    <div class="cursor-pointer dropdown-entry" wire:click="deleteSelected">
-                                        @lang('hermes::menus.notifications-dropdown.mark_selected_as_delete')
-                                    </div>
-                                </div>
-                            </x-ark-dropdown>
+                            <div class="cursor-pointer dropdown-entry" wire:click="deleteSelected">
+                                @lang('hermes::menus.notifications-dropdown.mark_selected_as_delete')
+                            </div>
                         </div>
-                    @endif
+                    </x-ark-dropdown>
                 </div>
             </div>
             <button type="button" class="items-center justify-end hidden cursor-pointer sm:flex link" wire:click="markAllAsRead">@lang('hermes::actions.mark_all_as_read')</button>

--- a/src/Components/ManageNotifications.php
+++ b/src/Components/ManageNotifications.php
@@ -98,6 +98,8 @@ final class ManageNotifications extends Component
         foreach ($this->selectedNotifications as $notification) {
             $this->markAsRead($notification);
         }
+
+        $this->batchActionPerformed();
     }
 
     public function markAllAsRead(): void
@@ -110,11 +112,17 @@ final class ManageNotifications extends Component
         $this->user->notifications()->findOrFail($notificationId)->markAsUnread();
     }
 
+    public function batchActionPerformed(): void {
+        $this->selectedNotifications = [];
+    }
+
     public function markSelectedAsUnread(): void
     {
         foreach ($this->selectedNotifications as $notification) {
             $this->markAsUnread($notification);
         }
+
+        $this->batchActionPerformed();
     }
 
     public function markAsStarred(string $notificationId): void
@@ -127,6 +135,8 @@ final class ManageNotifications extends Component
         foreach ($this->selectedNotifications as $notification) {
             $this->markAsStarred($notification);
         }
+
+        $this->batchActionPerformed();
     }
 
     public function markAsUnstarred(string $notificationId): void
@@ -139,6 +149,8 @@ final class ManageNotifications extends Component
         foreach ($this->selectedNotifications as $notification) {
             $this->markAsUnstarred($notification);
         }
+
+        $this->batchActionPerformed();
     }
 
     public function deleteNotification(string $notificationId): void
@@ -152,7 +164,7 @@ final class ManageNotifications extends Component
             $this->deleteNotification($notification);
         }
 
-        $this->selectedNotifications = [];
+        $this->batchActionPerformed();
     }
 
     public function getStateColor(DatabaseNotification $notification): string

--- a/src/Components/ManageNotifications.php
+++ b/src/Components/ManageNotifications.php
@@ -112,7 +112,8 @@ final class ManageNotifications extends Component
         $this->user->notifications()->findOrFail($notificationId)->markAsUnread();
     }
 
-    public function batchActionPerformed(): void {
+    public function batchActionPerformed(): void
+    {
         $this->selectedNotifications = [];
     }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/gd0tzt

1. Unselect the notifications when an action is performed
2. The "batch"  menu is only shown when at least one notification is selected

![image](https://user-images.githubusercontent.com/17262776/114792016-22fd4b80-9d4d-11eb-8241-40e2e1d68ab7.png)
![image](https://user-images.githubusercontent.com/17262776/114792030-28f32c80-9d4d-11eb-8964-ac45878ed347.png)


To test update msq and go to the notifications section `/user/notifications`


## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
