### PR TITLE
refactor: show announcement changes in notification component

### DIFF
--- a/resources/views/components/manage-notifications.blade.php
+++ b/resources/views/components/manage-notifications.blade.php
@@ -138,10 +138,10 @@
                                     </div>
                                     <div class="leading-5 text-theme-secondary-600">
                                         <div class="flex flex-col sm:block">
-                                            <span>{{ $notification->data['content'] }}</span>
-                                            @isset($notification->data['action'])
-                                                <a href="{{ $notification->data['action']['url'] }}" class="font-semibold link">{{ $notification->data['action']['title'] }}</a>
-                                            @endisset
+                                            <span>{{ $notification->content() }}</span>
+                                            @if($notification->hasAction())
+                                                <a href="{{ $notification->link() }}" class="font-semibold link">{{ $notification->title() }}</a>
+                                            @endif
                                         </div>
                                     </div>
                                 </div>

--- a/resources/views/navbar-notifications.blade.php
+++ b/resources/views/navbar-notifications.blade.php
@@ -18,15 +18,15 @@
 
                         <div class="flex flex-col justify-between md:space-x-3 md:flex-row">
                             <span class="notification-truncate">
-                                {{ $notification->data['content'] }}
+                                {{ $notification->content() }}
                             </span>
 
                             <div class="flex flex-row space-x-4">
-                                @isset($notification->data['action'])
+                                @if($notification->hasAction())
                                     <span class="mt-1 font-semibold whitespace-nowrap link md:mt-0">
-                                        <a href="{{ $notification->data['action']['url'] }}">{{ $notification->data['action']['title'] }}</a>
+                                        <a href="{{ $notification->link() }}">{{ $notification->title() }}</a>
                                     </span>
-                                @endisset
+                                @endif
 
                                 <span class="block mt-1 text-sm md:hidden text-theme-secondary-400">
                                     {{ $notification->created_at_local->diffForHumans() }}

--- a/src/Models/DatabaseNotification.php
+++ b/src/Models/DatabaseNotification.php
@@ -4,6 +4,7 @@ namespace ARKEcosystem\Hermes\Models;
 
 use ARKEcosystem\Fortify\Models\Concerns\HasLocalizedTimestamps;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Notifications\DatabaseNotification as BaseNotification;
 use Illuminate\Support\Arr;
@@ -65,18 +66,21 @@ abstract class DatabaseNotification extends BaseNotification
 
     public function title(): ?string
     {
+        /* @phpstan-ignore-next-line  */
         return data_get($this->relatable, 'title')
             ?? data_get($this->data, 'action.title');
     }
 
     public function content(): ?string
     {
+        /* @phpstan-ignore-next-line  */
         return data_get($this->relatable, 'body')
             ?? data_get($this->data, 'content');
     }
 
     public function link(): ?string
     {
+        /* @phpstan-ignore-next-line  */
         return data_get($this->relatable, 'link')
             ?? data_get($this->data, 'action.url');
     }

--- a/src/Models/DatabaseNotification.php
+++ b/src/Models/DatabaseNotification.php
@@ -62,4 +62,27 @@ abstract class DatabaseNotification extends BaseNotification
     abstract public function name(): string;
 
     abstract public function logo(): string;
+
+    public function title(): ?string
+    {
+        return data_get($this->relatable, 'title')
+            ?? data_get($this->data, 'action.title');
+    }
+
+    public function content(): ?string
+    {
+        return data_get($this->relatable, 'body')
+            ?? data_get($this->data, 'content');
+    }
+
+    public function link(): ?string
+    {
+        return data_get($this->relatable, 'link')
+            ?? data_get($this->data, 'action.url');
+    }
+
+    public function hasAction(): bool
+    {
+        return (bool) data_get($this->data, 'action');
+    }
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
https://app.clickup.com/t/nzft1p

This PR takes care of the announcement updates and show them correctly in the notification component.

### How to test
1. merge this PR on an app like MSQ
1. log in and go to Nova Admin Panel
1. create a new announcement
1. go to the homepage and open the notification from the navbar (the bell icon)
1. you will see your announcement
1. go to `/user/notifications`
1. you will see your announcement
1. back to Nova and edit the content of the previously created announcement and save
1. go to the homepage and open the notification from the navbar (the bell icon) again
1. you will see your announcement with the latest changes
1. go to `/user/notifications`
1. you will see your announcement with the latest changes

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
