### PR TITLE
refactor: always load relatable model for notifications

### DIFF
--- a/src/Models/Concerns/HasNotifications.php
+++ b/src/Models/Concerns/HasNotifications.php
@@ -18,6 +18,7 @@ trait HasNotifications
     {
         return $this
             ->morphMany(config('hermes.models.notification'), 'notifiable')
+            ->with('relatable')
             ->orderBy('created_at', 'desc')
             ->orderBy('id');
     }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

This is a part of https://app.clickup.com/t/pvc3dg. We use the related model when displaying notification icon so we need to load it to prevent n+1, made more sense to load it every time instead of "when needed", since we need it pretty much all the time.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
