### PR TITLE
refactor: use ui notification dot component

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -83,16 +83,16 @@
         },
         {
             "name": "arkecosystem/ui",
-            "version": "3.0.1",
+            "version": "3.39.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ArkEcosystem/laravel-ui.git",
-                "reference": "7bebb8b2ad3b58dae8b3a4f513f024ccd2a3f215"
+                "reference": "7040b42a744de2c10bdd394997f18d1e0cea1aff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ArkEcosystem/laravel-ui/zipball/7bebb8b2ad3b58dae8b3a4f513f024ccd2a3f215",
-                "reference": "7bebb8b2ad3b58dae8b3a4f513f024ccd2a3f215",
+                "url": "https://api.github.com/repos/ArkEcosystem/laravel-ui/zipball/7040b42a744de2c10bdd394997f18d1e0cea1aff",
+                "reference": "7040b42a744de2c10bdd394997f18d1e0cea1aff",
                 "shasum": ""
             },
             "require": {
@@ -153,9 +153,9 @@
             "description": "User-Interface Scaffolding for Laravel. Powered by TailwindCSS.",
             "support": {
                 "issues": "https://github.com/ArkEcosystem/laravel-ui/issues",
-                "source": "https://github.com/ArkEcosystem/laravel-ui/tree/3.0.1"
+                "source": "https://github.com/ArkEcosystem/laravel-ui/tree/3.39.1"
             },
-            "time": "2021-04-14T13:17:50+00:00"
+            "time": "2021-08-02T13:10:06+00:00"
         },
         {
             "name": "bacon/bacon-qr-code",

--- a/resources/views/components/notifications-indicator.blade.php
+++ b/resources/views/components/notifications-indicator.blade.php
@@ -1,7 +1,5 @@
 <div class="group">
     @if($this->notificationsUnread ?? false)
-        <span class="absolute right-0 block p-1 mr-2 -mt-4 bg-white rounded-full transition-default group-hover:bg-theme-primary-100">
-            <span class="block w-1 h-1 rounded-full border-3 bg-theme-danger-500 border-theme-danger-500"></span>
-        </span>
+        <x-ark-notification-dot />
     @endif
 </div>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Waiting on https://github.com/ArkEcosystem/laravel-ui/pull/590

Updates the notification dot in the navbar to use the component from UI - the only difference should be the red colour has changes slightly

Before:
![image](https://user-images.githubusercontent.com/8069294/129892356-b1a414b8-bfb2-4ac9-8d47-5369ba541ec5.png)

After:
![image](https://user-images.githubusercontent.com/8069294/129893147-da2f11c1-e425-4425-bab6-4c2e4f8d4d80.png)

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
